### PR TITLE
Address Melissa Amos's feedback.

### DIFF
--- a/less/puppetdocs.less
+++ b/less/puppetdocs.less
@@ -20,6 +20,17 @@ b, strong {
   font-weight: @font-weight-bold;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  &strong {
+    color: @brand-amber;
+  }
+}
+
 a {
   font-weight: @font-weight-medium;
 }

--- a/less/puppetdocs.less
+++ b/less/puppetdocs.less
@@ -26,7 +26,7 @@ h3,
 h4,
 h5,
 h6 {
-  &strong {
+  & strong {
     color: @brand-amber;
   }
 }

--- a/less/type.less
+++ b/less/type.less
@@ -165,6 +165,14 @@ ol {
   }
 }
 
+// Re-align ol items to match ul items.
+ol {
+  padding-left: 2rem;
+  li {
+    padding-left: 0.5rem;
+  }
+}
+
 // List options
 
 // Unstyled keeps list items block level, just removes default browser padding and list-style

--- a/less/variables.less
+++ b/less/variables.less
@@ -53,7 +53,7 @@
 @font-size-large:         (@font-size-base * 1.25);  // ~22px
 @font-size-small:         (@font-size-base * 0.836364);  // ~14.72px
 
-@font-size-h1:            (@font-size-base * 2.6);   // ~46px
+@font-size-h1:            (@font-size-base * 2.9);   // ~51px
 @font-size-h2:            (@font-size-base * 2.15);  // ~38px
 @font-size-h3:            (@font-size-base * 1.7);   // ~30px
 @font-size-h4:            (@font-size-base * 1.25);  // ~22px


### PR DESCRIPTION
- Increase the h1 size to match the main site's (~3.2rem, ~51px).
- Realign ordered list item numerals to match unordered list item bullets.
- Color &lt;strong&gt; text in headings.
