### PR TITLE
Make code blocks scroll horizontally at >80 chars.

### DIFF
--- a/less/code.less
+++ b/less/code.less
@@ -56,9 +56,12 @@ pre {
     padding: 0;
     font-size: inherit;
     color: inherit;
-    white-space: pre-wrap;
     background-color: transparent;
     border-radius: 0;
+    overflow-x: auto;
+    word-wrap: normal;
+    white-space: pre;
+    overflow-wrap: normal;
   }
 }
 


### PR DESCRIPTION
- Add overflow-x: auto to `pre code` to enable horizontal scrolling.
- Override deprecated `word-wrap`, supported `overflow-wrap`, and `white-space` to prevent line breaks in `pre code`.
