### PR TITLE
Make dropdown buttons match our site scheme

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -85,6 +85,10 @@
 .btn-danger {
   .button-variant(@btn-danger-color; @btn-danger-bg; @btn-danger-border);
 }
+// Branded nav buttons for Puppet docs
+.btn-nav {
+  .button-variant(@brand-amber; @navbar-inverse-bg; @navbar-inverse-border);
+}
 
 
 // Link buttons

--- a/less/buttons.less
+++ b/less/buttons.less
@@ -87,7 +87,7 @@
 }
 // Branded nav buttons for Puppet docs
 .btn-nav {
-  .button-variant(@brand-amber; @navbar-inverse-bg; @navbar-inverse-border);
+  .button-variant(#fff; @navbar-inverse-bg; @navbar-inverse-border);
 }
 
 

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -153,7 +153,7 @@
 .dropdown-header {
   display: block;
   padding: 3px 20px;
-  font-size: @font-size-small;
+  font-weight: @font-weight-bold;
   line-height: @line-height-base;
   color: @dropdown-header-color;
   white-space: nowrap; // as with > li > a

--- a/less/variables.less
+++ b/less/variables.less
@@ -240,31 +240,31 @@
 //## Dropdown menu container and contents.
 
 //** Background for the dropdown menu.
-@dropdown-bg:                    #fff;
+@dropdown-bg:                    #222;
 //** Dropdown menu `border-color`.
-@dropdown-border:                rgba(0,0,0,.15);
+@dropdown-border:                darken(@dropdown-bg, 10%);
 //** Dropdown menu `border-color` **for IE8**.
-@dropdown-fallback-border:       #ccc;
+@dropdown-fallback-border:       #111;
 //** Divider color for between dropdown items.
 @dropdown-divider-bg:            #e5e5e5;
 
 //** Dropdown link text color.
-@dropdown-link-color:            @gray-dark;
+@dropdown-link-color:            @brand-amber;
 //** Hover color for dropdown links.
-@dropdown-link-hover-color:      darken(@gray-dark, 5%);
+@dropdown-link-hover-color:      #fff;
 //** Hover background for dropdown links.
-@dropdown-link-hover-bg:         #f5f5f5;
+@dropdown-link-hover-bg:         transparent;
 
 //** Active dropdown menu item text color.
-@dropdown-link-active-color:     @component-active-color;
+@dropdown-link-active-color:     #fff;
 //** Active dropdown menu item background color.
-@dropdown-link-active-bg:        @component-active-bg;
+@dropdown-link-active-bg:        transparent;
 
 //** Disabled dropdown menu item background color.
 @dropdown-link-disabled-color:   @gray-light;
 
 //** Text color for headers within dropdown menus.
-@dropdown-header-color:          @gray-light;
+@dropdown-header-color:          #fff;
 
 //** Deprecated `@dropdown-caret-color` as of v3.1.0
 @dropdown-caret-color:           #000;


### PR DESCRIPTION
- Add a new .btn-nav class for white-text-on-navbar-dark-gray / hover-amber-text buttons. 
- Fix styling of dropdown headers.
- Change colors for dropdowns to match navbar-inverse instead of navbar-default. 
