### PR TITLE
Fix blockquote heading top margin.

### DIFF
--- a/less/puppetdocs.less
+++ b/less/puppetdocs.less
@@ -181,4 +181,13 @@ div#version-note {
 /* Blockquote notes */
 blockquote {
   .callout(@brand-amber);
+  
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-top: 0;
+  }
 }


### PR DESCRIPTION
Remove top margins from headings inside of blockquote tags.
